### PR TITLE
TPM emulation helper, make clean target and QEMU parametrization

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,17 +25,35 @@ $O/chainload/chainload: FORCE
 $O/initrd.cpio.xz: build/chainload/chainload FORCE
 	$(MAKE) -C initrd
 
-qemu: $O/bootx64.efi
-	qemu-system-x86_64 \
-		-M q35,accel=kvm \
-		-m 2G \
-		-drive if=pflash,format=raw,readonly,file=/usr/share/OVMF/OVMF_CODE.fd \
-		-drive if=pflash,format=raw,file=config/OVMF_VARS.fd \
-		-netdev user,id=eth0,tftp=.,bootfile=$O/bootx64.efi \
-		-device e1000,netdev=eth0 \
-		-serial stdio \
-		-cdrom win10.iso \
-		-hda win10.img
+# Arguments/parameters for QEMU, allowing for customization through make vars
+_OVMF := /usr/share/OVMF/OVMF_CODE.fd
+_OVMFSTATE := config/OVMF_VARS.fd
+_BOOT := ,tftp=.,bootfile=$O/bootx64.efi
+_NET  := -netdev user,id=eth0$(_BOOT) -device e1000,netdev=eth0
+_WIN  := -cdrom win10.iso -drive format=raw,file=win10.img,index=0,media=disk
 
+# see https://qemu-project.gitlab.io/qemu/specs/tpm.html
+_TPMSTATE := -incoming "exec:cat < testvm.bin"
+_TPM  := -chardev socket,id=chrtpm,path=/tmp/mytpm1/swtpm-sock \
+	  -tpmdev emulator,id=tpm0,chardev=chrtpm -device tpm-tis,tpmdev=tpm0
+ifeq ($(TPMSTATE),1)
+	_TPM += $(_TPMSTATE)
+endif
+
+# Extra arguments and optional changes for QEMU invocation
+_QEMUARGS := $(_NET) $(_WIN)
+ifeq ($(TPM),1)
+	_QEMUARGS += $(_TPM)
+endif
+_NOGRAPHIC := -nographic -monitor /dev/null
+ifeq ($(NOGRAPHIC),1)
+ 	_QEMUARGS += $(_NOGRAPHIC)
+endif
+
+qemu: $O/bootx64.efi
+	qemu-system-x86_64 -M q35,accel=kvm -cpu host -m 2G -serial stdio \
+		-drive if=pflash,format=raw,readonly=on,file=$(_OVMF) \
+		-drive if=pflash,format=raw,file=$(_OVMFSTATE) \
+		$(_QEMUARGS)
 
 FORCE:

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ all: $O/bootx64.efi | $O
 $O:
 	mkdir -p $@
 
+clean:
+		rm -rf $O/chainload
+		rm -rf $O/initrd*
+
 $O/bootx64.efi: $O/chainload/loader.efi $O/vmlinuz $O/initrd.cpio.xz
 	$O/chainload/unify-kernel $@ \
 		linux=$O/vmlinuz \

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ Creating the local machine state (not including the TPM):
 qemu-img create win10.hda 12G
 ```
 
+### Running in QEMU
 
 Launching the emulator is messy due to the need to pass in the separate
 UEFI nvram (the one in `config/OVMF_VARS.fd` has been modified so that
@@ -156,7 +157,17 @@ qemu-system-x86_64 \
   -hda win10.img
 ```
 
-Todo:
+### TPM emulation
+
+To emulate a TPM 2.0, run the script `./tpm.sh`. It will create a UNIX socket
+that QEMU can pick up. Run with `make TPM=1 qemu`.
+
+### Debugging
+
+For more convenient debugging, you can turn off the graphical QEMU window:
+`make NOGRAPHIC=1 qemu`
+
+### Todo
 
 * [X] Wrap kernel building in the `Makefile`
 * [X] `initrd.cpio` building
@@ -171,4 +182,3 @@ memmap=exactmap,32K@0G,512M@1G noefi acpi=off
 
 * [ ] Make the loader built this addition to the command line
 * [ ] Allocate the SMP trampoline correclty in UEFI
-

--- a/tpm.sh
+++ b/tpm.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+mkdir -p /tmp/mytpm1
+swtpm socket --tpmstate dir=/tmp/mytpm1 --log level=20 --tpm2 \
+    --ctrl type=unixio,path=/tmp/mytpm1/swtpm-sock


### PR DESCRIPTION
 With the `make clean` target, rebuilding is a bit easier:

```sh
make clean && make build//chainload/chainload && and make all
```